### PR TITLE
[BUGFIX] Replace deprecated hasDeletedRecord usage with DatabaseUtility check

### DIFF
--- a/Classes/Hook/ProcessCmdmap.php
+++ b/Classes/Hook/ProcessCmdmap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Interest\Hook;
 
 use FriendsOfTYPO3\Interest\Domain\Repository\RemoteIdMappingRepository;
+use FriendsOfTYPO3\Interest\Utility\DatabaseUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -33,7 +34,7 @@ class ProcessCmdmap
         $pasteUpdate,
         $pasteDatamap
     ): void {
-        if ($command === 'delete' && $dataHandler->hasDeletedRecord($table, $id)) {
+        if ($command === 'delete' && DatabaseUtility::getRecord($table, $id) === null) {
             /** @var RemoteIdMappingRepository $mappingRepository */
             $mappingRepository = GeneralUtility::makeInstance(RemoteIdMappingRepository::class);
 


### PR DESCRIPTION
The method DataHandler::hasDeletedRecord() has been removed in TYPO3 v13.  
In the ProcessCmdmap hook this method was previously used to verify that a
record was actually deleted before removing the remote ID mapping.

This change replaces the call with a `DatabaseUtility::getRecord()` check,
ensuring the record no longer exists before proceeding. This approach maintains
the intended safeguard while removing the dependency on the deprecated API.