### PR TITLE
[BUGFIX] Use DBAL result in pending relations command

### DIFF
--- a/Classes/Command/PendingRelationsCommandController.php
+++ b/Classes/Command/PendingRelationsCommandController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Interest\Command;
 
-use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Result;
 use FriendsOfTYPO3\Interest\DataHandling\DataHandler;
 use FriendsOfTYPO3\Interest\Domain\Repository\Exception\InvalidQueryResultException;
 use FriendsOfTYPO3\Interest\Domain\Repository\PendingRelationsRepository;


### PR DESCRIPTION
Use Doctrine\DBAL\Result for the pending relations query result.

Align the command with TYPO3 QueryBuilder::executeQuery(), which returns a Doctrine\DBAL\Result instance for select queries. This allows resolvable pending relations to be processed again.

Resolves: #142